### PR TITLE
refactor: centralize format display name mapping

### DIFF
--- a/src/main/kotlin/cn/kurt6/cobblemon_ranked/commands/RankCommands.kt
+++ b/src/main/kotlin/cn/kurt6/cobblemon_ranked/commands/RankCommands.kt
@@ -4,6 +4,7 @@ import cn.kurt6.cobblemon_ranked.CobblemonRanked
 import cn.kurt6.cobblemon_ranked.config.ConfigManager
 import cn.kurt6.cobblemon_ranked.config.MessageConfig
 import cn.kurt6.cobblemon_ranked.matchmaking.DuoMatchmakingQueue
+import cn.kurt6.cobblemon_ranked.util.RankUtils
 import com.mojang.brigadier.CommandDispatcher
 import com.mojang.brigadier.arguments.IntegerArgumentType
 import com.mojang.brigadier.arguments.StringArgumentType
@@ -497,12 +498,7 @@ object RankCommands {
 
         val playersText = formats.joinToString(" ") { format ->
             val count = participationByFormat[format] ?: 0
-            val formatName = when (format) {
-                "singles" -> if (lang == "zh") "单打" else "Singles"
-                "doubles" -> if (lang == "zh") "双打" else "Doubles"
-                "2v2singles" -> if (lang == "zh") "2v2单打" else "2v2 Singles"
-                else -> format
-            }
+            val formatName = RankUtils.getFormatDisplayName(format, lang)
             "§a$formatName: §f$count"
         }
 

--- a/src/main/kotlin/cn/kurt6/cobblemon_ranked/network/ServerNetworking.kt
+++ b/src/main/kotlin/cn/kurt6/cobblemon_ranked/network/ServerNetworking.kt
@@ -64,12 +64,7 @@ class ServerNetworking {
 
             val playersText = formats.joinToString(" ") { format ->
                 val count = participationByFormat[format] ?: 0
-                val formatName = when (format) {
-                    "singles" -> if (lang == "zh") "单打" else "Singles"
-                    "doubles" -> if (lang == "zh") "双打" else "Doubles"
-                    "2v2singles" -> if (lang == "zh") "2v2单打" else "2v2Singles"
-                    else -> format
-                }
+                val formatName = RankUtils.getFormatDisplayName(format, lang)
                 "§a$formatName: §f$count"
             }
 

--- a/src/main/kotlin/cn/kurt6/cobblemon_ranked/util/RankUtils.kt
+++ b/src/main/kotlin/cn/kurt6/cobblemon_ranked/util/RankUtils.kt
@@ -9,6 +9,16 @@ import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.text.Text
 
 object RankUtils {
+    fun getFormatDisplayName(format: String, lang: String): String {
+        val normalizedLang = lang.lowercase()
+        return when (format) {
+            "singles" -> if (normalizedLang == "zh") "单打" else "Singles"
+            "doubles" -> if (normalizedLang == "zh") "双打" else "Doubles"
+            "2v2singles" -> if (normalizedLang == "zh") "2v2单打" else "2v2 Singles"
+            else -> format
+        }
+    }
+
     fun sendMessage(player: PlayerEntity, message: String) {
         player.sendMessage(Text.literal(message), false)
     }


### PR DESCRIPTION
### Motivation
- Centralize the mapping of battle format identifiers (`singles`, `doubles`, `2v2singles`) to localized display names to remove repeated `when` branches and make future format additions simpler and less error-prone.
- Keep command-side and network-side season/format messaging consistent by reusing a single helper.

### Description
- Added `RankUtils.getFormatDisplayName(format, lang)` to provide a single place for localized format display names.
- Replaced inline `when` format-to-name logic in `ServerNetworking` with calls to `RankUtils.getFormatDisplayName(format, lang)`.
- Updated `RankCommands` to reuse `RankUtils.getFormatDisplayName(format, lang)` and added the corresponding import.
- Removed duplicated branching logic for format display names to reduce maintenance surface.

### Testing
- Attempted to run `gradle compileKotlin compileClientKotlin`, which failed in this environment due to a Gradle/toolchain error (`25.0.1`) and therefore compilation could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a53b6ef9b883218e40517dde7d8246)